### PR TITLE
Switch to a unified deferral queue for the various integration contexts.

### DIFF
--- a/daml_dit_if/main/integration_deferral_queue.py
+++ b/daml_dit_if/main/integration_deferral_queue.py
@@ -1,0 +1,34 @@
+import asyncio
+
+from typing import Callable
+
+from .log import LOG
+
+
+DeferredAction = Callable[[], None]
+
+class IntegrationDeferralQueue:
+
+    def __init__(self):
+        self.queue = \
+            asyncio.Queue(maxsize=10)  # type: asyncio.Queue[DeferredAction]
+
+    async def put(self, action: DeferredAction):
+        await self.queue.put(action)
+
+    def qsize(self):
+        return self.queue.qsize()
+
+    async def start(self):
+        LOG.debug('Deferral worker starting.')
+
+        while True:
+            LOG.debug('Waiting for deferred action.')
+
+            try:
+                fn = await self.queue.get()
+                LOG.info('Processing deferred action.')
+                await fn()
+
+            except:  # noqa: E722
+                LOG.exception('Uncaught error in deferral queue worker loop')

--- a/daml_dit_if/main/integration_webhook_context.py
+++ b/daml_dit_if/main/integration_webhook_context.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence
 from functools import wraps
 
 from aiohttp import web
 from aiohttp.web import RouteTableDef
+
+from dazl import AIOPartyClient
 
 from .common import \
     InvocationStatus, \
@@ -14,6 +16,8 @@ from ..api import IntegrationWebhookRoutes
 
 from .log import LOG
 
+from .integration_deferral_queue import \
+    IntegrationDeferralQueue
 
 def empty_success_response() -> 'web.HTTPOk':
     return web.HTTPOk()
@@ -33,7 +37,7 @@ class IntegrationWebhookStatus:
 
 class IntegrationWebhookContext(IntegrationWebhookRoutes):
 
-    def __init__(self, client):
+    def __init__(self, queue: 'IntegrationDeferralQueue', client: 'AIOPartyClient'):
         self.route_table = RouteTableDef()
         self.client = client
 


### PR DESCRIPTION
This simplifies the runtime structure of integrations by consolidating three internal work queues to a single work queue. No real cost here, and it opens the door for better and more consistent error/retry handling across various sorts of integration events.