### PR TITLE
Paramaterize metadata filename and add a ledger command submission timeout.

### DIFF
--- a/daml_dit_if/api/__init__.py
+++ b/daml_dit_if/api/__init__.py
@@ -31,6 +31,7 @@ from ..main.auth_accessors import \
 def _empty_commands() -> 'Sequence[Command]':
     return list()
 
+
 @dataclass(frozen=True)
 class IntegrationResponse:
     """
@@ -38,6 +39,7 @@ class IntegrationResponse:
     a sequence of zero or more ledger commands to issue.
     """
     commands: 'Optional[Sequence[Command]]' = field(default_factory=_empty_commands)
+    command_timeout: 'int' = 5
 
 
 class IntegrationQueueSink:

--- a/daml_dit_if/main/config.py
+++ b/daml_dit_if/main/config.py
@@ -2,15 +2,18 @@ import os
 from dataclasses import dataclass, asdict
 from typing import Optional
 
-from .log import FAIL, LOG
+from daml_dit_api import \
+    DABL_META_NAME
 
+from .log import FAIL, LOG
 
 @dataclass(frozen=True)
 class Configuration:
     health_port: int
     ledger_url: str
     ledger_id: str
-    integration_metadata_path: str
+    dit_meta_path: str
+    integration_spec_path: str
     type_id: 'Optional[str]'
     run_as_party: 'Optional[str]'
     log_level: int
@@ -52,7 +55,8 @@ def get_default_config() -> 'Configuration':
         health_port=envint('DABL_HEALTH_PORT', 8089),
         ledger_url=env('DABL_LEDGER_URL', 'http://localhost:6865'),
         ledger_id=env('DABL_LEDGER_ID', 'cloudbox'),
-        integration_metadata_path=env('DABL_INTEGRATION_METADATA_PATH', 'int_args.yaml'),
+        dit_meta_path=env('DAML_DIT_META_PATH', DABL_META_NAME),
+        integration_spec_path=env('DABL_INTEGRATION_METADATA_PATH', 'int_args.yaml'),
         type_id=optenv('DABL_INTEGRATION_TYPE_ID'),
         run_as_party=optenv('DAML_LEDGER_PARTY'),
         log_level=envint('DABL_LOG_LEVEL', 0),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daml-dit-if"
-version = "0.6.0"
+version = "0.6.1"
 description = "Daml Hub Integration Framework"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
 readme = "README.md"


### PR DESCRIPTION
Parameterize the local metadata filename - this allows external control over where a locally run (non-PEX) integration finds its `dit-meta.yaml` file. This in turn is used by `ddit` to allow injection of enriched metadata into a locally running integration. (Necessary for getting the default Daml model package ID into the integration.)

This also adds a command submission timeout to integrations. This allows recovery from the case when an integration issues a command that takes no effect on the ledger's ACS. (This scenario does not produce a TXN event, so Dazl never understands that an action-free command has been processed.)