### PR TITLE
Defer the full ledger startup until AFTER the web endpoint is working and able to respond to health checks.

### DIFF
--- a/daml_dit_if/main/integration_webhook_context.py
+++ b/daml_dit_if/main/integration_webhook_context.py
@@ -92,7 +92,7 @@ class IntegrationWebhookContext(IntegrationWebhookRoutes):
     def _notice_hook_route(self, url_path: str, method: str,
                            label: 'Optional[str]') -> 'WebhookRouteStatus':
 
-        LOG.debug('Registered hook (label: %s): %s %r', label, method, url_path)
+        LOG.info('Registered hook (label: %s): %s %r', label, method, url_path)
 
         route_status = \
             WebhookRouteStatus(

--- a/daml_dit_if/main/main.py
+++ b/daml_dit_if/main/main.py
@@ -63,7 +63,6 @@ async def run_dazl_network(network: 'Network'):
     """
     Run the dazl network, and make sure that fatal dazl errors terminate the application.
     """
-
     try:
         LOG.info('Starting dazl network...')
 
@@ -88,7 +87,7 @@ async def _aio_main(
         IntegrationContext(
             network, config.run_as_party, integration_type, type_id, integration_spec, metadata)
 
-    await integration_context.safe_load_and_start()
+    await integration_context.safe_load()
 
     integration_coro = integration_context.get_coro()
 
@@ -97,9 +96,11 @@ async def _aio_main(
 
         web_coro = start_web_endpoint(config, integration_context)
 
-        LOG.info('Starting main loop.')
+        integration_startup_coro = integration_context.safe_start()
 
-        await gather(web_coro, dazl_coro, integration_coro)
+        LOG.info('Starting main loop.')
+        await gather(
+            web_coro, dazl_coro, integration_coro, integration_startup_coro)
 
         return True
 

--- a/daml_dit_if/main/web.py
+++ b/daml_dit_if/main/web.py
@@ -101,6 +101,8 @@ async def start_web_endpoint(
         config: 'Configuration',
         integration_context: 'IntegrationContext'):
 
+    LOG.info('Starting web endpoint...')
+
     web_coros = []
 
     # prepare the web application
@@ -120,7 +122,7 @@ async def start_web_endpoint(
 
     app.add_routes(_build_control_routes(integration_context))
 
-    if integration_context.running and integration_context.webhook_context:
+    if integration_context.webhook_context:
         app.add_routes(integration_context.webhook_context.route_table)
 
     LOG.info('Starting web server on %s...', config.health_port)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daml-dit-if"
-version = "0.6.2"
+version = "0.6.3"
 description = "Daml Hub Integration Framework"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
 readme = "README.md"


### PR DESCRIPTION
With large active contract sets, integrations can take long enough to fully start their web endpoint (with the health check) that K8s assumes they've failed and restarts them before they're fully launched.  This PR puts the full ledger startup _after_ the web endpoint startup, which makes it possible to respond with a positive health check response early enough to keep this from happening. The web endpoint becomes immediately available, with the `running` status flag used to indicate whether or not the integration is fully operational.

Note that this change also relaxes an earlier guarantee made by the IF - namely that ledger sweep events are always processed before any other event. With this change, it becomes possible for other events to be processed during the initial ledger sweep. Integrations should be designed for this possibility. 