### PR TITLE
Reconfigure the deferral queue to operate more reliably under high load.

### DIFF
--- a/daml_dit_if/main/common.py
+++ b/daml_dit_if/main/common.py
@@ -14,6 +14,15 @@ from ..api import IntegrationResponse
 from .log import LOG
 
 
+
+@dataclass(frozen=True)
+class IntegrationQueueStatus:
+    queue_size: int
+    total_events: int
+    pending_events: int
+    skipped_events: int
+
+
 @dataclass
 class InvocationStatus:
     index: int

--- a/daml_dit_if/main/config.py
+++ b/daml_dit_if/main/config.py
@@ -18,6 +18,7 @@ class Configuration:
     run_as_party: 'Optional[str]'
     log_level: int
     jwks_url: 'Optional[str]'
+    queue_size: int
 
 
 def optenv(var: str) -> 'Optional[str]':
@@ -60,7 +61,8 @@ def get_default_config() -> 'Configuration':
         type_id=optenv('DABL_INTEGRATION_TYPE_ID'),
         run_as_party=optenv('DAML_LEDGER_PARTY'),
         log_level=envint('DABL_LOG_LEVEL', 0),
-        jwks_url=optenv('DABL_JWKS_URL'))
+        jwks_url=optenv('DABL_JWKS_URL'),
+        queue_size=envint('DABL_QUEUE_SIZE', 512))
 
     LOG.info('Configuration: %r', asdict(config))
 

--- a/daml_dit_if/main/integration_time_context.py
+++ b/daml_dit_if/main/integration_time_context.py
@@ -58,7 +58,14 @@ class IntegrationTimeContext(IntegrationTimeEvents):
             while True:
                 LOG.debug('Wait loop waiting %r seconds...', seconds)
                 await asyncio.sleep(seconds)
-                await self.queue.put(fn, status)
+
+                try:
+                    await self.queue.put(fn, status)
+
+                except asyncio.QueueFull:
+                    LOG.debug('Ignoring full event queue and continuing timer loop')
+                    pass
+
         except:  # noqa: E722
             LOG.exception('Unexpected error in wait loop (%r, %r).', seconds, fn)
 

--- a/daml_dit_if/main/main.py
+++ b/daml_dit_if/main/main.py
@@ -85,7 +85,7 @@ async def _aio_main(
 
     integration_context = \
         IntegrationContext(
-            network, config.run_as_party, integration_type, type_id, integration_spec, metadata)
+            network, config, integration_type, type_id, integration_spec, metadata)
 
     await integration_context.safe_load()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daml-dit-if"
-version = "0.6.4"
+version = "0.6.5"
 description = "Daml Hub Integration Framework"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
 readme = "README.md"


### PR DESCRIPTION
* Increase the size of the deferral queue from 10 elements to 512 (and make configurable via an environment variable)
* Switch to a non-blocking/event-skipping approach for the deferral queue. (This implies events will be dropped under high load.)
* Remove ledger event processing from the deferral queue. (It's important not to skip these events for integrations that maintain an ACS view.)
* Expose more queue statistics via the health check endpoint.