### PR TITLE
Clean up some unused imports

### DIFF
--- a/daml_dit_if/api/common.py
+++ b/daml_dit_if/api/common.py
@@ -7,7 +7,7 @@ from aiohttp.typedefs import LooseHeaders
 from daml_dit_api import DamlModelInfo
 from dazl.damlast.lookup import parse_type_con_name
 from dazl.damlast.util import package_ref
-from dazl.protocols.v0.json_ser_command import LedgerJSONEncoder
+from dazl.prim.json import JSONEncoder
 
 LOG = logging.getLogger('daml-dit-if')
 
@@ -28,7 +28,7 @@ def ensure_package_id(daml_model: 'Optional[DamlModelInfo]', template: str) -> s
 
 
 
-DEFAULT_ENCODER = LedgerJSONEncoder()
+DEFAULT_ENCODER = JSONEncoder()
 
 
 def json_response(

--- a/daml_dit_if/main/auth_handler.py
+++ b/daml_dit_if/main/auth_handler.py
@@ -1,4 +1,4 @@
-from typing import Any, Awaitable, Callable, Mapping, Optional, TypeVar
+from typing import Awaitable, Callable, Optional
 
 from aiohttp.web import Application, Request, Response
 from aiohttp.web_middlewares import middleware

--- a/daml_dit_if/main/integration_context.py
+++ b/daml_dit_if/main/integration_context.py
@@ -1,14 +1,10 @@
 import asyncio
-import os
 import sys
 from dataclasses import dataclass
 from datetime import datetime
-from functools import wraps
 from importlib import import_module
-from types import ModuleType
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type
+from typing import Any, Optional, Sequence, Type
 
-import yaml
 from dacite import Config, from_dict
 from daml_dit_api import (
     METADATA_COMMON_RUN_AS_PARTY,
@@ -19,8 +15,8 @@ from daml_dit_api import (
     IntegrationTypeInfo,
     PackageMetadata,
 )
-from dazl import AIOPartyClient, Command, Network
-from dazl.util.prim_types import to_boolean
+from dazl import Network
+from dazl.prim import to_bool as to_boolean
 
 from ..api import IntegrationEntryPoint, IntegrationEnvironment, IntegrationEvents
 from .common import (

--- a/daml_dit_if/main/integration_ledger_context.py
+++ b/daml_dit_if/main/integration_ledger_context.py
@@ -1,11 +1,8 @@
-import asyncio
 from dataclasses import dataclass
 from typing import Any, Callable, List, Optional, Sequence, Tuple
 
 from daml_dit_api import DamlModelInfo
 from dazl import AIOPartyClient
-from dazl.damlast.lookup import parse_type_con_name
-from dazl.damlast.util import package_ref
 from dazl.model.core import ContractMatch
 from dazl.model.reading import ContractCreateEvent
 from dazl.model.writing import EventHandlerResponse

--- a/daml_dit_if/main/integration_queue_context.py
+++ b/daml_dit_if/main/integration_queue_context.py
@@ -1,6 +1,4 @@
-import asyncio
-from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Awaitable, Callable, Dict, Sequence, Tuple
 
 from dazl import AIOPartyClient, Command
 

--- a/daml_dit_if/main/integration_time_context.py
+++ b/daml_dit_if/main/integration_time_context.py
@@ -1,8 +1,7 @@
 import asyncio
-from dataclasses import dataclass
 from typing import Callable, List, Optional, Sequence, Tuple
 
-from dazl import AIOPartyClient, Command
+from dazl import AIOPartyClient
 
 from ..api import IntegrationTimeEvents
 from .common import InvocationStatus, as_handler_invocation, without_return_value

--- a/daml_dit_if/main/integration_webhook_context.py
+++ b/daml_dit_if/main/integration_webhook_context.py
@@ -3,7 +3,6 @@ from functools import wraps
 from typing import List, Optional, Sequence
 
 from aiohttp import web
-from aiohttp.helpers import sentinel
 from aiohttp.web import RouteTableDef
 from dazl import AIOPartyClient
 

--- a/daml_dit_if/main/package_metadata_introspection.py
+++ b/daml_dit_if/main/package_metadata_introspection.py
@@ -1,9 +1,9 @@
 import sys
-from typing import Dict, Optional
+from typing import Optional
 from zipfile import ZipFile
 
 import yaml
-from dacite import Config, from_dict
+from dacite import from_dict
 from daml_dit_api import (
     DABL_META_NAME,
     DamlModelInfo,

--- a/daml_dit_if/main/web.py
+++ b/daml_dit_if/main/web.py
@@ -1,9 +1,8 @@
 import re
 from asyncio import ensure_future, gather
-from dataclasses import asdict, dataclass
-from typing import Any, Dict, Optional
+from dataclasses import asdict
+from typing import Optional
 
-from aiohttp import web
 from aiohttp.web import (
     AccessLogger,
     Application,

--- a/poetry.lock
+++ b/poetry.lock
@@ -506,6 +506,22 @@ python-versions = "*"
 version = "1.4.3"
 
 [[package]]
+category = "dev"
+description = "Typing stubs for PyYAML"
+name = "types-pyyaml"
+optional = false
+python-versions = "*"
+version = "6.0.3"
+
+[[package]]
+category = "dev"
+description = "Typing stubs for setuptools"
+name = "types-setuptools"
+optional = false
+python-versions = "*"
+version = "57.4.7"
+
+[[package]]
 category = "main"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 name = "typing-extensions"
@@ -575,7 +591,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 develop = []
 
 [metadata]
-content-hash = "5d6fb1074a466dacec98ddd70c5dbbab5dff6a29c8f5b1dd3f16713d06524809"
+content-hash = "4855f02b093c999ebecc9d3a36501e89dc807570a88c5aded916cc54e373b16e"
 python-versions = ">=3.7, <4.0"
 
 [metadata.files]
@@ -1016,6 +1032,14 @@ typed-ast = [
     {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
     {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
+]
+types-pyyaml = [
+    {file = "types-PyYAML-6.0.3.tar.gz", hash = "sha256:6ea4eefa8579e0ce022f785a62de2bcd647fad4a81df5cf946fd67e4b059920b"},
+    {file = "types_PyYAML-6.0.3-py3-none-any.whl", hash = "sha256:8b50294b55a9db89498cdc5a65b1b4545112b6cd1cf4465bd693d828b0282a17"},
+]
+types-setuptools = [
+    {file = "types-setuptools-57.4.7.tar.gz", hash = "sha256:9677d969b00ec1c14552f5be2b2b47a6fbea4d0ed4de0fdcee18abdaa0cc9267"},
+    {file = "types_setuptools-57.4.7-py3-none-any.whl", hash = "sha256:ffda504687ea02d4b7751c0d1df517fbbcdc276836d90849e4f1a5f1ccd79f01"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ pytest = "^5.4.3"
 pytest-asyncio = "*"
 pytest-codestyle = "*"
 isort = "^5.10.1"
+types-PyYAML = "^6.0.3"
+types-setuptools = "^57.4.7"
 
 [tool.poetry.extras]
 develop = []


### PR DESCRIPTION
* Clean up some unused imports.
* Remove imports for deprecated dazl APIs where possible.
* Add typing stub references for pyyaml and setuptools, as they are no longer included in mypy as of 0.900.