### PR TITLE
add option to set application name for DAZL netwwork

### DIFF
--- a/daml_dit_if/main/main.py
+++ b/daml_dit_if/main/main.py
@@ -51,8 +51,9 @@ def load_integration_spec(config: 'Configuration') -> 'Optional[IntegrationRunti
 
 def create_network(url: str) -> 'Network':
     token = optenv("DAML_LEDGER_TOKEN")
+    app_name = optenv("DAML_LEDGER_APPLICATION_NAME")
     network = Network()
-    network.set_config(url=url, oauth_token=token)
+    network.set_config(url=url, oauth_token=token, application_name=app_name)
     return network
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daml-dit-if"
-version = "0.6.7"
+version = "0.6.8"
 description = "Daml Hub Integration Framework"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
 readme = "README.md"


### PR DESCRIPTION
> This adds the option to set the application name in the Dazl network via an environment variable override to avoid `PERMISSION_DENIED(7,0): Claims are only valid for applicationId damlhub, actual applicationId is DAZL-Client.` errors when running using `ddit run` locally.

@alexgraham-da Since the claims are in the JWT, can you derive the application ID from the JWT if it's passed in? That might simplify usage.
