### PR TITLE
add exception handler

### DIFF
--- a/daml_dit_if/api/__init__.py
+++ b/daml_dit_if/api/__init__.py
@@ -4,7 +4,7 @@ import abc
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Awaitable, Callable, Optional, Sequence
 
 from aiohttp.helpers import sentinel
 from aiohttp.web import Response
@@ -38,6 +38,7 @@ class IntegrationResponse:
     """
 
     commands: Optional[Sequence[Command]] = field(default_factory=_empty_commands)
+    error_handler: Optional[Callable[[Exception], Awaitable[None]]] = None
     command_timeout: int = 30
 
 

--- a/daml_dit_if/main/common.py
+++ b/daml_dit_if/main/common.py
@@ -85,10 +85,13 @@ def as_handler_invocation(client: "AIOPartyClient", inv_status: "InvocationStatu
                 )
 
                 inv_status.command_count += len(response.commands)
-
-                await wait_for(
-                    client.submit(response.commands), response.command_timeout
-                )
+                try:
+                    await wait_for(
+                        client.submit(response.commands), response.command_timeout
+                    )
+                except Exception as e:
+                    if response.error_handler:
+                        await response.error_handler(e)
 
             return response
 


### PR DESCRIPTION
Adds the ability to create an exception handler callback in an integration when a command submission fails.

Working example of usage: 
```python


    @events.ledger.contract_created('CoinDesk.PriceRequest:FailureTest')
    async def on_contract_created(event):

        async def handle_error(e: Exception):
            LOG.info(f"Hit an exception when trying to submit a command: {e}!")
            commands = [exercise(event.cid, 'FailureTest_Succeed', {})]
            await env.queue.put({"event": event, "exception": e, "commands": commands}, "contract_errors")

        return IntegrationResponse(
                commands=[exercise(event.cid, 'FailureTest_Fail', {})],
                error_handler=handle_error
            )

    @events.queue.message("contract_errors")
    async def on_message(msg):
        event = msg['event']
        exception = msg['exception']
        commands = msg['commands']
        LOG.info(f'Handling error queue for {event} with exception {exception}...')
        return commands
```