### PR TITLE
Add 'from __future__ import annotations', and drop quotes around type annotations.

### DIFF
--- a/daml_dit_if/api/__init__.py
+++ b/daml_dit_if/api/__init__.py
@@ -26,7 +26,7 @@ from .common import (
 )
 
 
-def _empty_commands() -> "Sequence[Command]":
+def _empty_commands() -> Sequence[Command]:
     return list()
 
 
@@ -44,7 +44,7 @@ class IntegrationResponse:
 
 class IntegrationQueueSink:
     @abc.abstractmethod
-    async def put(self, message: "Any", queue_name: "str" = "default"):
+    async def put(self, message: Any, queue_name: str = "default"):
         """
         Put a message onto the internal message queue with the given
         name. Throws an exception if there is no queue of that name.
@@ -54,7 +54,7 @@ class IntegrationQueueSink:
 
 class IntegrationQueueEvents:
     @abc.abstractmethod
-    def message(self, queue_name: "str" = "default"):
+    def message(self, queue_name: str = "default"):
         """
         Register a function as a handler for internal queue message events.
         The function will be invoked for each message placed on the message
@@ -68,7 +68,7 @@ class IntegrationQueueEvents:
 
 class IntegrationTimeEvents:
     @abc.abstractmethod
-    def periodic_interval(self, seconds, label: "Optional[str]" = None):
+    def periodic_interval(self, seconds, label: Optional[str] = None):
         """
         Register a function as a handler for periodic timer events. The
         function will be scheduled to run at the specified
@@ -123,7 +123,7 @@ class IntegrationLedgerTransactionEvent:
 
     command_id: str
     workflow_id: str
-    contract_events: "Sequence[IntegrationLedgerContractEvent]"
+    contract_events: Sequence[IntegrationLedgerContractEvent]
 
 
 @dataclass(frozen=True)
@@ -184,7 +184,7 @@ class IntegrationLedgerEvents:
     def contract_created(
         self,
         template: Any,
-        match: "Optional[ContractMatch]" = None,
+        match: Optional[ContractMatch] = None,
         sweep: bool = True,
         flow: bool = True,
     ):
@@ -208,7 +208,7 @@ class IntegrationLedgerEvents:
         """
 
     @abc.abstractmethod
-    def contract_archived(self, template: Any, match: "Optional[ContractMatch]" = None):
+    def contract_archived(self, template: Any, match: Optional[ContractMatch] = None):
         """
         Decorator for registering a callback to be invoked when the integration
         encounters a newly archived contract instance of a template.
@@ -228,13 +228,13 @@ class IntegrationWebhookResponse(IntegrationResponse):
     HTTP response.
     """
 
-    response: "Optional[Response]" = None
+    response: Optional[Response] = None
 
     json_response: Any = sentinel
-    text_response: "Optional[str]" = None
-    blob_response: "Optional[bytes]" = None
+    text_response: Optional[str] = None
+    blob_response: Optional[bytes] = None
 
-    http_content_type: "Optional[str]" = None
+    http_content_type: Optional[str] = None
     http_status: int = 200
 
 
@@ -248,9 +248,9 @@ class IntegrationWebhookRoutes:
     @abc.abstractmethod
     def post(
         self,
-        url_suffix: "Optional[str]" = None,
-        label: "Optional[str]" = None,
-        auth: "Optional[AuthorizationLevel]" = AuthorizationLevel.PUBLIC,
+        url_suffix: Optional[str] = None,
+        label: Optional[str] = None,
+        auth: Optional[AuthorizationLevel] = AuthorizationLevel.PUBLIC,
     ):
         """
         Register a function as an HTTP POST handler for the integration's webhook.
@@ -269,9 +269,9 @@ class IntegrationWebhookRoutes:
     @abc.abstractmethod
     def get(
         self,
-        url_suffix: "Optional[str]" = None,
-        label: "Optional[str]" = None,
-        auth: "Optional[AuthorizationLevel]" = AuthorizationLevel.PUBLIC,
+        url_suffix: Optional[str] = None,
+        label: Optional[str] = None,
+        auth: Optional[AuthorizationLevel] = AuthorizationLevel.PUBLIC,
     ):
         """
         Register a function as an HTTP GET handler for the integration's webhook.
@@ -290,17 +290,17 @@ class IntegrationWebhookRoutes:
 
 @dataclass
 class IntegrationEvents:
-    queue: "IntegrationQueueEvents"
-    time: "IntegrationTimeEvents"
-    ledger: "IntegrationLedgerEvents"
-    webhook: "IntegrationWebhookRoutes"
+    queue: IntegrationQueueEvents
+    time: IntegrationTimeEvents
+    ledger: IntegrationLedgerEvents
+    webhook: IntegrationWebhookRoutes
 
 
 @dataclass
 class IntegrationEnvironment:
-    queue: "IntegrationQueueSink"
+    queue: IntegrationQueueSink
     party: str
-    daml_model: "Optional[DamlModelInfo]"
+    daml_model: Optional[DamlModelInfo]
 
     def tid(self, template_id: str) -> str:
         return ensure_package_id(self.daml_model, template_id)

--- a/daml_dit_if/api/common.py
+++ b/daml_dit_if/api/common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Any, Optional
 
@@ -12,7 +14,7 @@ from dazl.prim.json import JSONEncoder
 LOG = logging.getLogger("daml-dit-if")
 
 
-def ensure_package_id(daml_model: "Optional[DamlModelInfo]", template: str) -> str:
+def ensure_package_id(daml_model: Optional[DamlModelInfo], template: str) -> str:
 
     if template == "*":
         return template
@@ -39,9 +41,9 @@ def json_response(
     text: str = None,
     body: bytes = None,
     status: int = 200,
-    reason: "Optional[str]" = None,
-    headers: "LooseHeaders" = None,
-) -> "web.Response":
+    reason: Optional[str] = None,
+    headers: LooseHeaders = None,
+) -> web.Response:
     return web.json_response(
         data=data,
         text=text,
@@ -53,37 +55,37 @@ def json_response(
     )
 
 
-def empty_success_response() -> "web.HTTPOk":
+def empty_success_response() -> web.HTTPOk:
     return web.HTTPOk()
 
 
 def blob_success_response(
-    body: bytes, content_type: "Optional[str]" = "application/octet-stream"
+    body: bytes, content_type: Optional[str] = "application/octet-stream"
 ) -> "web.HTTPOk":
 
     return web.HTTPOk(body=body, content_type=content_type)
 
 
-def unauthorized_response(code: str, description: str) -> "web.HTTPUnauthorized":
+def unauthorized_response(code: str, description: str) -> web.HTTPUnauthorized:
     body = DEFAULT_ENCODER.encode({"code": code, "description": description}) + "\n"
     return web.HTTPUnauthorized(text=body, content_type="application/json")
 
 
-def forbidden_response(code: str, description: str) -> "web.HTTPForbidden":
+def forbidden_response(code: str, description: str) -> web.HTTPForbidden:
     body = DEFAULT_ENCODER.encode({"code": code, "description": description}) + "\n"
     return web.HTTPForbidden(text=body, content_type="application/json")
 
 
-def not_found_response(code: str, description: str) -> "web.HTTPNotFound":
+def not_found_response(code: str, description: str) -> web.HTTPNotFound:
     body = DEFAULT_ENCODER.encode({"code": code, "description": description}) + "\n"
     return web.HTTPNotFound(text=body, content_type="application/json")
 
 
-def bad_request(code: str, description: str) -> "web.HTTPBadRequest":
+def bad_request(code: str, description: str) -> web.HTTPBadRequest:
     body = DEFAULT_ENCODER.encode({"code": code, "description": description}) + "\n"
     return web.HTTPBadRequest(text=body, content_type="application/json")
 
 
-def internal_server_error(code: str, description: str) -> "web.HTTPInternalServerError":
+def internal_server_error(code: str, description: str) -> web.HTTPInternalServerError:
     body = DEFAULT_ENCODER.encode({"code": code, "description": description}) + "\n"
     return web.HTTPInternalServerError(text=body, content_type="application/json")

--- a/daml_dit_if/main/__init__.py
+++ b/daml_dit_if/main/__init__.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from .main import main
 from .util import is_true

--- a/daml_dit_if/main/__main__.py
+++ b/daml_dit_if/main/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .main import main
 
 main()

--- a/daml_dit_if/main/auth_accessors.py
+++ b/daml_dit_if/main/auth_accessors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from aiohttp.web import Request
@@ -10,8 +12,8 @@ DABL_JWT_LEDGER_CLAIMS = "DABL_JWT_LEDGER_CLAIMS"
 
 
 def get_configured_integration_ledger_claims(
-    config: "Configuration", claims: "JWTClaims"
-) -> "Optional[JWTClaims]":
+    config: Configuration, claims: JWTClaims
+) -> Optional[JWTClaims]:
 
     """
     Given an IF configuration and a dict of claims from a DAML Ledger
@@ -39,7 +41,7 @@ def get_configured_integration_ledger_claims(
 
 
 def is_integration_party_ledger_claim(
-    config: "Configuration", ledger_claims: "JWTClaims"
+    config: Configuration, ledger_claims: JWTClaims
 ) -> bool:
     """
     Given an IF configuration and a dict of DAML ledger claims from
@@ -58,7 +60,7 @@ def is_integration_party_ledger_claim(
     return party in read_as_parties and party in act_as_parties
 
 
-def get_request_claims(request: "Request"):
+def get_request_claims(request: Request):
     """
     Return the DAML ledger claims for the request's JWT token. If there
     are no such claims, or the token has not been extracted (as in a
@@ -67,7 +69,7 @@ def get_request_claims(request: "Request"):
     return request.get(DABL_JWT_LEDGER_CLAIMS, None)
 
 
-def get_request_parties(request: "Request"):
+def get_request_parties(request: Request):
     """
     Get the DAML ledger parties identified in the current request's JWT
     token. The parties returned by this function are the parties that
@@ -86,7 +88,7 @@ def get_request_parties(request: "Request"):
     return list(set(read_as_parties).intersection(set(act_as_parties)))
 
 
-def get_single_request_party(request: "Request"):
+def get_single_request_party(request: Request):
     """
     Returns the single DAML ledger party identified in the current request's
     JWT. For a party to be returned by this function, it must appear in _both_

--- a/daml_dit_if/main/common.py
+++ b/daml_dit_if/main/common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import sys
 from asyncio import wait_for
@@ -23,12 +25,12 @@ class IntegrationQueueStatus:
 @dataclass
 class InvocationStatus:
     index: int
-    label: "Optional[str]"
+    label: Optional[str]
     command_count: int
     use_count: int
     error_count: int
-    error_message: "Optional[str]"
-    error_time: "Optional[datetime]"
+    error_message: Optional[str]
+    error_time: Optional[datetime]
 
 
 def without_return_value(fn):
@@ -67,7 +69,7 @@ def normalize_integration_response(response):
     return IntegrationResponse(commands=commands)
 
 
-def as_handler_invocation(client: "AIOPartyClient", inv_status: "InvocationStatus", fn):
+def as_handler_invocation(client: AIOPartyClient, inv_status: InvocationStatus, fn):
     @wraps(fn)
     async def wrapped(*args, **kwargs):
         LOG.debug("Invoking for invocation status: %r", inv_status)

--- a/daml_dit_if/main/config.py
+++ b/daml_dit_if/main/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from dataclasses import asdict, dataclass
 from typing import Optional
@@ -21,7 +23,7 @@ class Configuration:
     queue_size: int
 
 
-def optenv(var: str) -> "Optional[str]":
+def optenv(var: str) -> Optional[str]:
     val = os.getenv(var)
 
     LOG.debug("Configuration environment lookup: %r => %r", var, val)
@@ -29,7 +31,7 @@ def optenv(var: str) -> "Optional[str]":
     return val
 
 
-def env(var: str, default: "Optional[str]" = None) -> str:
+def env(var: str, default: Optional[str] = None) -> str:
     val = optenv(var)
 
     if val:
@@ -46,7 +48,7 @@ def env(var: str, default: "Optional[str]" = None) -> str:
         return ""  # unreached
 
 
-def envint(var: str, default: "Optional[int]" = None) -> int:
+def envint(var: str, default: Optional[int] = None) -> int:
     val = env(var, None if default is None else str(default))
 
     try:
@@ -55,7 +57,7 @@ def envint(var: str, default: "Optional[int]" = None) -> int:
         FAIL(f"Invalid integer {val} in environment variable: {var}")
 
 
-def get_default_config() -> "Configuration":
+def get_default_config() -> Configuration:
     config = Configuration(
         health_port=envint("DABL_HEALTH_PORT", 8089),
         ledger_url=env("DABL_LEDGER_URL", "http://localhost:6865"),

--- a/daml_dit_if/main/integration_context.py
+++ b/daml_dit_if/main/integration_context.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import sys
 from dataclasses import dataclass
@@ -39,14 +41,14 @@ from .log import FAIL, LOG
 class IntegrationStatus:
     running: bool
     start_time: datetime
-    error_message: "Optional[str]"
-    error_time: "Optional[datetime]"
+    error_message: Optional[str]
+    error_time: Optional[datetime]
     pending_events: int
-    event_queue: "IntegrationQueueStatus"
-    webhooks: "Sequence[WebhookRouteStatus]"
-    ledger_events: "Sequence[LedgerHandlerStatus]"
-    timers: "Sequence[InvocationStatus]"
-    queues: "Sequence[InvocationStatus]"
+    event_queue: IntegrationQueueStatus
+    webhooks: Sequence[WebhookRouteStatus]
+    ledger_events: Sequence[LedgerHandlerStatus]
+    timers: Sequence[InvocationStatus]
+    queues: Sequence[InvocationStatus]
 
 
 def normalize_metadata_field(field_value, field_type_info):
@@ -98,12 +100,12 @@ def parse_qualified_symbol(symbol_text: str):
 class IntegrationContext:
     def __init__(
         self,
-        network: "Network",
-        config: "Configuration",
-        integration_type: "IntegrationTypeInfo",
+        network: Network,
+        config: Configuration,
+        integration_type: IntegrationTypeInfo,
         type_id: str,
-        integration_spec: "IntegrationRuntimeSpec",
-        metadata: "PackageMetadata",
+        integration_spec: IntegrationRuntimeSpec,
+        metadata: PackageMetadata,
     ):
 
         self.start_time = datetime.utcnow()
@@ -152,16 +154,16 @@ class IntegrationContext:
             FAIL("DAML_LEDGER_PARTY environment variable undefined.")
 
     def get_integration_entrypoint(
-        self, integration_type: "IntegrationTypeInfo"
-    ) -> "IntegrationEntryPoint":
+        self, integration_type: IntegrationTypeInfo
+    ) -> IntegrationEntryPoint:
 
         (module, entry_fn_name) = parse_qualified_symbol(integration_type.entrypoint)
 
         return getattr(module, entry_fn_name)
 
     def get_integration_env_class(
-        self, integration_type: "IntegrationTypeInfo"
-    ) -> "Type[IntegrationEnvironment]":
+        self, integration_type: IntegrationTypeInfo
+    ) -> Type[IntegrationEnvironment]:
 
         if integration_type.env_class:
             (module, env_class_name) = parse_qualified_symbol(
@@ -237,7 +239,7 @@ class IntegrationContext:
         self.running = True
         LOG.info("...sweeps procesed, integration started.")
 
-    def get_status(self) -> "IntegrationStatus":
+    def get_status(self) -> IntegrationStatus:
         queue_status = self.queue.get_status()
 
         return IntegrationStatus(

--- a/daml_dit_if/main/integration_deferral_queue.py
+++ b/daml_dit_if/main/integration_deferral_queue.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from dataclasses import dataclass
 from typing import Callable
@@ -11,12 +13,12 @@ DeferredAction = Callable[[], None]
 
 @dataclass
 class IntegrationQueueAction:
-    action: "DeferredAction"
-    status: "InvocationStatus"
+    action: DeferredAction
+    status: InvocationStatus
 
 
 class IntegrationDeferralQueue:
-    def __init__(self, config: "Configuration"):
+    def __init__(self, config: Configuration):
         self.total_events = 0
         self.skipped_events = 0
         self.queue_size = config.queue_size
@@ -36,7 +38,7 @@ class IntegrationDeferralQueue:
             LOG.error("Work queue overrun, skipping event: %r", status)
             raise
 
-    def get_status(self) -> "IntegrationQueueStatus":
+    def get_status(self) -> IntegrationQueueStatus:
         return IntegrationQueueStatus(
             total_events=self.total_events,
             pending_events=self.queue.qsize(),

--- a/daml_dit_if/main/integration_ledger_context.py
+++ b/daml_dit_if/main/integration_ledger_context.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any, Callable, List, Optional, Sequence, Tuple
 
@@ -42,9 +44,9 @@ class LedgerHandlerStatus(InvocationStatus):
 class IntegrationLedgerContext(IntegrationLedgerEvents):
     def __init__(
         self,
-        queue: "IntegrationDeferralQueue",
-        client: "AIOPartyClient",
-        daml_model: "Optional[DamlModelInfo]",
+        queue: IntegrationDeferralQueue,
+        client: AIOPartyClient,
+        daml_model: Optional[DamlModelInfo],
     ):
         self.queue = queue
 
@@ -60,10 +62,10 @@ class IntegrationLedgerContext(IntegrationLedgerEvents):
     def _notice_handler(
         self,
         label: str,
-        template_id: "Optional[str]",
+        template_id: Optional[str],
         sweep_enabled: bool,
         flow_enabled: bool,
-    ) -> "LedgerHandlerStatus":
+    ) -> LedgerHandlerStatus:
 
         handler_status = LedgerHandlerStatus(
             index=len(self.handlers),
@@ -195,7 +197,7 @@ class IntegrationLedgerContext(IntegrationLedgerEvents):
     def contract_created(
         self,
         template: Any,
-        match: "Optional[ContractMatch]" = None,
+        match: Optional[ContractMatch] = None,
         sweep: bool = True,
         flow: bool = True,
         package_defaulting: bool = True,
@@ -238,7 +240,7 @@ class IntegrationLedgerContext(IntegrationLedgerEvents):
     def contract_archived(
         self,
         template: Any,
-        match: "Optional[ContractMatch]" = None,
+        match: Optional[ContractMatch] = None,
         package_defaulting: bool = True,
     ):
 
@@ -270,5 +272,5 @@ class IntegrationLedgerContext(IntegrationLedgerEvents):
 
         return wrap_method
 
-    def get_status(self) -> "Sequence[LedgerHandlerStatus]":
+    def get_status(self) -> Sequence[LedgerHandlerStatus]:
         return self.handlers

--- a/daml_dit_if/main/integration_queue_context.py
+++ b/daml_dit_if/main/integration_queue_context.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Awaitable, Callable, Dict, Sequence, Tuple
 
 from dazl import AIOPartyClient, Command
@@ -16,7 +18,7 @@ class IntegrationQueueSinkImpl(IntegrationQueueSink):
     def __init__(self, queues: IntegrationQueueDict):
         self.queues = queues
 
-    async def put(self, message: "Any", queue_name: "str" = "default"):
+    async def put(self, message: Any, queue_name: str = "default"):
 
         LOG.debug("Queue put (%r): %r", queue_name, message)
 
@@ -33,13 +35,13 @@ class IntegrationQueueSinkImpl(IntegrationQueueSink):
 
 
 class IntegrationQueueContext(IntegrationQueueEvents):
-    def __init__(self, queue: "IntegrationDeferralQueue", client: "AIOPartyClient"):
+    def __init__(self, queue: IntegrationDeferralQueue, client: AIOPartyClient):
         self.queue = queue
         self.client = client
         self.queues = {}  # type: IntegrationQueueDict
         self.sink = IntegrationQueueSinkImpl(self.queues)
 
-    def message(self, queue_name: "str" = "default"):
+    def message(self, queue_name: str = "default"):
         def decorator(fn: "IntegrationQueueHandler"):
             status = InvocationStatus(
                 index=len(self.queues),
@@ -72,5 +74,5 @@ class IntegrationQueueContext(IntegrationQueueEvents):
 
         return decorator
 
-    def get_status(self) -> "Sequence[InvocationStatus]":
+    def get_status(self) -> Sequence[InvocationStatus]:
         return [status for (_, status) in self.queues.values()]

--- a/daml_dit_if/main/integration_time_context.py
+++ b/daml_dit_if/main/integration_time_context.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from typing import Callable, List, Optional, Sequence, Tuple
 
@@ -12,14 +14,14 @@ IntegrationTimerHandler = Callable[[], None]
 
 
 class IntegrationTimeContext(IntegrationTimeEvents):
-    def __init__(self, queue: "IntegrationDeferralQueue", client: "AIOPartyClient"):
+    def __init__(self, queue: IntegrationDeferralQueue, client: AIOPartyClient):
         self.queue = queue
         self.client = client
         self.intervals = (
             []
         )  # type: List[Tuple[int, IntegrationTimerHandler,InvocationStatus]]
 
-    def periodic_interval(self, seconds, label: "Optional[str]" = None):
+    def periodic_interval(self, seconds, label: Optional[str] = None):
         label_text = label or "Periodic Interval"
 
         def decorator(fn: "IntegrationTimerHandler"):
@@ -71,5 +73,5 @@ class IntegrationTimeContext(IntegrationTimeEvents):
             ]
         )
 
-    def get_status(self) -> "Sequence[InvocationStatus]":
+    def get_status(self) -> Sequence[InvocationStatus]:
         return [status for (_, _, status) in self.intervals]

--- a/daml_dit_if/main/integration_webhook_context.py
+++ b/daml_dit_if/main/integration_webhook_context.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from functools import wraps
 from typing import List, Optional, Sequence
@@ -18,7 +20,7 @@ from .integration_deferral_queue import IntegrationDeferralQueue
 from .log import LOG
 
 
-def empty_success_response() -> "web.HTTPOk":
+def empty_success_response() -> web.HTTPOk:
     return web.HTTPOk()
 
 
@@ -28,7 +30,7 @@ class WebhookRouteStatus(InvocationStatus):
     method: str
 
 
-def get_http_response(hook_response: "IntegrationWebhookResponse"):
+def get_http_response(hook_response: IntegrationWebhookResponse):
     response = empty_success_response()  # type: web.Response
 
     if hook_response.response is not None:
@@ -70,7 +72,7 @@ def get_http_response(hook_response: "IntegrationWebhookResponse"):
 
 
 class IntegrationWebhookContext(IntegrationWebhookRoutes):
-    def __init__(self, queue: "IntegrationDeferralQueue", client: "AIOPartyClient"):
+    def __init__(self, queue: IntegrationDeferralQueue, client: AIOPartyClient):
         self.route_table = RouteTableDef()
         self.client = client
 
@@ -84,8 +86,8 @@ class IntegrationWebhookContext(IntegrationWebhookRoutes):
         return wrapped
 
     def _notice_hook_route(
-        self, url_path: str, method: str, label: "Optional[str]"
-    ) -> "WebhookRouteStatus":
+        self, url_path: str, method: str, label: Optional[str]
+    ) -> WebhookRouteStatus:
 
         LOG.info("Registered hook (label: %s): %s %r", label, method, url_path)
 
@@ -105,14 +107,14 @@ class IntegrationWebhookContext(IntegrationWebhookRoutes):
 
         return route_status
 
-    def _url_path(self, url_suffix: "Optional[str]"):
+    def _url_path(self, url_suffix: Optional[str]):
         return "/integration/{integration_id}" + (url_suffix or "")
 
     def post(
         self,
-        url_suffix: "Optional[str]" = None,
-        label: "Optional[str]" = None,
-        auth: "Optional[AuthorizationLevel]" = AuthorizationLevel.PUBLIC,
+        url_suffix: Optional[str] = None,
+        label: Optional[str] = None,
+        auth: Optional[AuthorizationLevel] = AuthorizationLevel.PUBLIC,
     ):
         path = self._url_path(url_suffix)
         hook_status = self._notice_hook_route(path, "post", label)
@@ -132,9 +134,9 @@ class IntegrationWebhookContext(IntegrationWebhookRoutes):
 
     def get(
         self,
-        url_suffix: "Optional[str]" = None,
-        label: "Optional[str]" = None,
-        auth: "Optional[AuthorizationLevel]" = AuthorizationLevel.PUBLIC,
+        url_suffix: Optional[str] = None,
+        label: Optional[str] = None,
+        auth: Optional[AuthorizationLevel] = AuthorizationLevel.PUBLIC,
     ):
         path = self._url_path(url_suffix)
         hook_status = self._notice_hook_route(path, "get", label)
@@ -152,5 +154,5 @@ class IntegrationWebhookContext(IntegrationWebhookRoutes):
 
         return wrap_method
 
-    def get_status(self) -> "Sequence[WebhookRouteStatus]":
+    def get_status(self) -> Sequence[WebhookRouteStatus]:
         return self.routes

--- a/daml_dit_if/main/jwt.py
+++ b/daml_dit_if/main/jwt.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from asyncio import shield, sleep
 from datetime import timedelta
@@ -19,7 +21,7 @@ JWTClaims = Mapping[str, Any]
 
 
 class JWTValidator:
-    def __init__(self, jwks_urls: "Optional[Union[str, Collection[str]]]" = None):
+    def __init__(self, jwks_urls: Optional[Union[str, Collection[str]]] = None):
         from jwcrypto.jwk import JWKSet
 
         self.jwks_urls = jwks_urls
@@ -38,7 +40,7 @@ class JWTValidator:
             await shield(self._load_new_keys())
             LOG.debug("...JWKS poll complete.")
 
-    async def decode_claims(self, token: str) -> "JWTClaims":
+    async def decode_claims(self, token: str) -> JWTClaims:
         from jwcrypto.jwt import JWT
 
         LOG.debug("Verifying token: %r", token)
@@ -49,7 +51,7 @@ class JWTValidator:
         jwt = JWT(jwt=token, key=self.keys)
         return json.loads(jwt.claims)
 
-    async def get_key(self, kid: str) -> "Optional[JWK]":
+    async def get_key(self, kid: str) -> Optional[JWK]:
         """
         Retrieve a key for a given ``kid``. If the key could not be found, the keystore is
         refreshed, and if a key is discovered through that process, it is returned. May return
@@ -63,7 +65,7 @@ class JWTValidator:
 
         return key
 
-    def export_all_keys(self) -> "str":
+    def export_all_keys(self) -> str:
         """
         Return a JSON string that formats all public keys currently in the store as JWKS.
         """

--- a/daml_dit_if/main/log.py
+++ b/daml_dit_if/main/log.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import sys
 import time

--- a/daml_dit_if/main/main.py
+++ b/daml_dit_if/main/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import base64
 import logging
@@ -30,9 +32,7 @@ from .package_metadata_introspection import get_package_metadata
 from .web import start_web_endpoint
 
 
-def load_integration_spec(
-    config: "Configuration",
-) -> "Optional[IntegrationRuntimeSpec]":
+def load_integration_spec(config: Configuration) -> Optional[IntegrationRuntimeSpec]:
     spec_path = Path(config.integration_spec_path)
 
     if spec_path.exists():
@@ -49,7 +49,7 @@ def load_integration_spec(
         return None
 
 
-def create_network(url: str) -> "Network":
+def create_network(url: str) -> Network:
     token = optenv("DAML_LEDGER_TOKEN")
     app_name = optenv("DAML_LEDGER_APPLICATION_NAME")
     network = Network()
@@ -57,7 +57,7 @@ def create_network(url: str) -> "Network":
     return network
 
 
-async def run_dazl_network(network: "Network"):
+async def run_dazl_network(network: Network):
     """
     Run the dazl network, and make sure that fatal dazl errors terminate the application.
     """
@@ -72,11 +72,11 @@ async def run_dazl_network(network: "Network"):
 
 
 async def _aio_main(
-    integration_type: "IntegrationTypeInfo",
-    config: "Configuration",
+    integration_type: IntegrationTypeInfo,
+    config: Configuration,
     type_id: str,
-    integration_spec: "IntegrationRuntimeSpec",
-    metadata: "PackageMetadata",
+    integration_spec: IntegrationRuntimeSpec,
+    metadata: PackageMetadata,
 ):
 
     network = create_network(config.ledger_url)
@@ -105,9 +105,7 @@ async def _aio_main(
     return False
 
 
-def _get_integration_types(
-    metadata: "PackageMetadata",
-) -> "Dict[str, IntegrationTypeInfo]":
+def _get_integration_types(metadata: PackageMetadata) -> Dict[str, IntegrationTypeInfo]:
 
     package_itypes = (
         metadata.integration_types

--- a/daml_dit_if/main/package_metadata_introspection.py
+++ b/daml_dit_if/main/package_metadata_introspection.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from typing import Optional
 from zipfile import ZipFile
@@ -15,7 +17,7 @@ from .config import Configuration
 from .log import LOG
 
 
-def _get_local_dabl_meta(config: "Configuration") -> "Optional[str]":
+def _get_local_dabl_meta(config: Configuration) -> Optional[str]:
     dit_meta_path = config.dit_meta_path
 
     LOG.debug("Attmpting to load DABL metadata from local file: %r", dit_meta_path)
@@ -28,7 +30,7 @@ def _get_local_dabl_meta(config: "Configuration") -> "Optional[str]":
         return None
 
 
-def _get_pex_dabl_meta() -> "Optional[str]":
+def _get_pex_dabl_meta() -> Optional[str]:
     pex_filename = sys.argv[0]
 
     LOG.debug("Attmpting to load DABL metadata from PEX file: %r", pex_filename)
@@ -45,7 +47,7 @@ def _get_pex_dabl_meta() -> "Optional[str]":
         return None
 
 
-def get_package_metadata(config: "Configuration") -> "PackageMetadata":
+def get_package_metadata(config: Configuration) -> PackageMetadata:
     dabl_meta = _get_pex_dabl_meta() or _get_local_dabl_meta(config)
 
     if dabl_meta:

--- a/daml_dit_if/main/util.py
+++ b/daml_dit_if/main/util.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from typing import Optional
 
 
-def is_true(value: "Optional[str]") -> bool:
+def is_true(value: Optional[str]) -> bool:
     if value is None:
         return False
 

--- a/daml_dit_if/main/web.py
+++ b/daml_dit_if/main/web.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from asyncio import ensure_future, gather
 from dataclasses import asdict
@@ -34,10 +36,10 @@ CLIENT_MAX_SIZE = 100 * (1024**2)
 LOG_SUPPRESSED_ROUTE_REGEX = re.compile("^(/integration/[\w]+)?/((healthz)|(status))$")
 
 
-def _build_control_routes(integration_context: "IntegrationContext") -> "RouteTableDef":
+def _build_control_routes(integration_context: IntegrationContext) -> RouteTableDef:
     routes = RouteTableDef()
 
-    def _get_status(request: "Request"):
+    def _get_status(request: Request):
         return {
             **asdict(integration_context.get_status()),
             "log_level": get_log_level(),
@@ -47,18 +49,18 @@ def _build_control_routes(integration_context: "IntegrationContext") -> "RouteTa
 
     @routes.get("/integration/{integration_id}/healthz")
     @auth_level(AuthorizationLevel.ANY_PARTY)
-    async def get_container_health(request: "Request") -> "Response":
+    async def get_container_health(request: Request) -> Response:
         response_dict = {**_get_status(request), "_self": str(request.url)}
         return json_response(response_dict)
 
     @routes.get("/integration/{integration_id}/status")
     @auth_level(AuthorizationLevel.ANY_PARTY)
-    async def get_container_status(request: "Request") -> "Response":
+    async def get_container_status(request: Request) -> Response:
         return json_response(_get_status(request))
 
     @routes.post("/integration/{integration_id}/log-level")
     @auth_level(AuthorizationLevel.ANY_PARTY)
-    async def set_level(request: "Request") -> "Response":
+    async def set_level(request: Request) -> Response:
         body = await request.json()
 
         set_log_level(int(body["log_level"]))
@@ -93,7 +95,7 @@ def _log_suppressed_route(path: str) -> bool:
 
 
 class IntegrationAccessLogger(AccessLogger):
-    def log(self, request: "BaseRequest", response: "StreamResponse", time: float):
+    def log(self, request: BaseRequest, response: StreamResponse, time: float):
 
         path = request.rel_url.path
 
@@ -105,7 +107,7 @@ class IntegrationAccessLogger(AccessLogger):
 
 
 async def start_web_endpoint(
-    config: "Configuration", integration_context: "IntegrationContext"
+    config: Configuration, integration_context: IntegrationContext
 ):
 
     LOG.info("Starting web endpoint...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daml-dit-if"
-version = "0.6.10"
+version = "0.6.11"
 description = "Daml Hub Integration Framework"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
 readme = "README.md"
@@ -31,6 +31,7 @@ black = "^22.6.0"
 develop = []
 
 [tool.isort]
+add_imports = ["from __future__ import annotations"]
 profile = "black"
 
 [build-system]


### PR DESCRIPTION
Add `from __future__ import annotations`, and drop quotes around type annotations.

Quotes around type names are really just a hacky workaround that Python 3.6 and earlier used to allow for forward type references, but the improved parser in Python 3.7 copes with forward type references much better, so opt in to using it, and remove the quotes.

This also means that in some cases, bad types result in runtime errors as well as errors when checking statically, which further increases the chance that bad typing rules are caught early.