### PR TITLE
Another version bump to pick up daml-dit-api@0.5.0.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -440,18 +440,14 @@ dev = ["black", "coveralls", "mypy", "pre-commit", "pylint", "pytest (>=5)", "py
 
 [[package]]
 name = "daml-dit-api"
-version = "0.4.5"
+version = "0.5.0"
 description = "Daml Hub DIT File API Package"
 optional = false
-python-versions = ">=3.7,<4.0"
+python-versions = ">=3.8,<4.0"
 files = [
-    {file = "daml-dit-api-0.4.5.tar.gz", hash = "sha256:08c036e7190498674cf57b8cb89b76b583e6eeb49e47e2ad6e329574b6e80bf5"},
-    {file = "daml_dit_api-0.4.5-py3-none-any.whl", hash = "sha256:0af6af35cd634497e5164f6f642547a739d42f621bf4e409837903080c82a043"},
+    {file = "daml_dit_api-0.5.0-py3-none-any.whl", hash = "sha256:c1e70d292b73c6452a0fd8edfdbc747f25515e8e519cf6ae773bca96176efee9"},
+    {file = "daml_dit_api-0.5.0.tar.gz", hash = "sha256:0b8069d273a6d783db4c0fff530c40eb06e9f9f44667e2fa5330cd1961b4f2ed"},
 ]
-
-[package.dependencies]
-aiohttp = "*"
-dazl = ">=7,<8"
 
 [[package]]
 name = "dazl"
@@ -1373,4 +1369,4 @@ develop = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <4.0"
-content-hash = "e0506bc1c4011636cd688346ad6e9ca80bf48728c1a599ce15c527eb19d48cbe"
+content-hash = "43f1e67a398bdfc9c0bc2a2b3d60d94ee2aa50c6ed201ff4c59af6af488a323f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daml-dit-if"
-version = "0.7.0"
+version = "0.7.1"
 description = "Daml Hub Integration Framework"
 authors = ["Daml Hub Team <no-reply@digitalasset.com>"]
 readme = "README.md"
@@ -14,7 +14,7 @@ dacite = "*"
 idna = "*"
 pyyaml = "*"
 dazl = "^7"
-daml-dit-api = "^0.4.3"
+daml-dit-api = "*"
 jwcrypto = "*"
 prometheus-client = "*"
 


### PR DESCRIPTION
Whoops… didn't quite do this right in #44… this _actually_ allows people to use newer versions of `daml-dit-api`.